### PR TITLE
Fix: Malformed media query

### DIFF
--- a/assets/css/safari-flexbox-fixes.css
+++ b/assets/css/safari-flexbox-fixes.css
@@ -5,7 +5,7 @@
  */
 
 /* Fix Flexbox issues for Safari 6.1-10.0 */
-@media screen and (min-color-index:0) and(-webkit-min-device-pixel-ratio:0) {
+@media screen and (min-color-index:0) and (-webkit-min-device-pixel-ratio:0) {
 	@media {
 		.content-area,
 		.sidebar,

--- a/functions.php
+++ b/functions.php
@@ -151,7 +151,7 @@ function wellington_scripts() {
 	wp_enqueue_style( 'wellington-stylesheet', get_stylesheet_uri(), array(), $theme_version );
 
 	// Register and Enqueue Safari Flexbox CSS fixes.
-	wp_enqueue_style( 'wellington-safari-flexbox-fixes', get_template_directory_uri() . '/assets/css/safari-flexbox-fixes.css', array(), '20200420' );
+	wp_enqueue_style( 'wellington-safari-flexbox-fixes', get_template_directory_uri() . '/assets/css/safari-flexbox-fixes.css', array(), '20210810' );
 
 	// Register and Enqueue HTML5shiv to support HTML5 elements in older IE versions.
 	wp_enqueue_script( 'html5shiv', get_template_directory_uri() . '/assets/js/html5shiv.min.js', array(), '3.7.3' );


### PR DESCRIPTION
The issue has been reported by Google Search Console's AMP Validator. for more info please check the support topic 
https://wordpress.org/support/topic/css-syntax-error-in-tag-style-amp-custom-malformed-media-query-3/